### PR TITLE
Fixed typo in parameter command

### DIFF
--- a/lib/Mojolicious/Plugin/Process.pm
+++ b/lib/Mojolicious/Plugin/Process.pm
@@ -35,7 +35,7 @@
         my ( $stdout_stream, $stderr_stream ) = _gen_stream(
             $stdout, $stderr,
             pid     => $pid,
-            comman  => $command,
+            command => $command,
             timeout => $timeout,
         );
 


### PR DESCRIPTION
Please verify, but to me it seems like a typo.
