### PR TITLE
Start reactor if it is not running

### DIFF
--- a/lib/Mojolicious/Plugin/Process.pm
+++ b/lib/Mojolicious/Plugin/Process.pm
@@ -48,6 +48,9 @@
 
         _watch( $pid, $stdout_stream, $stderr_stream );
 
+        # Start event loop only if it is not running already
+        Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
+
         return (wantarray) ? ($pid, $stdin) : $pid;
     }
 

--- a/t/command.t
+++ b/t/command.t
@@ -1,0 +1,38 @@
+package Mojolicious::Plugin::Process::Command::Hello;
+use Mojo::Base 'Mojolicious::Command';
+
+sub run {
+  my $self = shift;
+  my ( $pid, $stdin ) = $self->app->process(
+    command => [ qw/perl -e/, 'local $| = 1; sleep 3; print "Hello STDOUT"; print STDERR "Hello STDERR"' ],
+    stdout  => {
+      read => sub {
+        my ($stream, $chunk) = @_;
+        print "$chunk";
+      },
+    },
+  );
+}
+
+package main;
+use Mojo::Base qw{ -strict };
+use Test::More tests => 1;
+use Mojolicious;
+use Mojolicious::Command;
+use Capture::Tiny qw{ capture_stdout };
+
+local $SIG{ALRM} = sub {
+    BAIL_OUT("test failed. probably the problem happend in capture_stderr.");
+};
+alarm 10;
+
+my $app = Mojolicious->new;
+$app->plugin('Process');
+$app->commands->namespaces(['Mojolicious::Plugin::Process::Command']);
+
+my $stdout = capture_stdout {
+  $app->start('Hello');
+};
+is $stdout, "Hello STDOUT";
+
+done_testing;


### PR DESCRIPTION
When it does not start a server, `process` is not able to handle specified command because the reactor does not start.

I also considered that I should begin the reactor at the concrete sub class of `Command`. However, existence of `Mojo::IOLoop` is not seen from `Command` side, so I have written the code in `process`.

I'm not conversant about the event loop. I don't know whether this way is appropriate, but it looks good to me.
